### PR TITLE
Bug- New Backlog item cannot be created

### DIFF
--- a/src/Presentation/Taskist.Web/Helpers/Mapping/AutoMapperProfile.cs
+++ b/src/Presentation/Taskist.Web/Helpers/Mapping/AutoMapperProfile.cs
@@ -59,7 +59,9 @@ public class AutoMapperProfile : Profile
 
         CreateMap<Backlog, BacklogModel>().ReverseMap()
             .ForMember(dest => dest.Code, act => act.Ignore())
-            .ForMember(dest => dest.AssigneeId, opt => opt.MapFrom(src => src.AssigneeId == -1 ? (int?)null : src.AssigneeId));
+            .ForMember(dest => dest.AssigneeId, opt => opt.MapFrom(src => src.AssigneeId == -1 ? (int?)null : src.AssigneeId))
+            .ForMember(dest => dest.SprintId, opt => opt.MapFrom(src => src.SprintId == -1 ? (int?)null : src.SprintId))
+            .ForMember(dest => dest.ReporterId, opt => opt.MapFrom(src => src.ReporterId == -1 ? (int?)null : src.ReporterId));
 
         CreateMap<Sprint, SprintModel>().ReverseMap();
         CreateMap<CustomField, CustomFieldRenderModel>();


### PR DESCRIPTION
Error- : The INSERT statement conflicted with the FOREIGN KEY constraint "FK_Backlog_Reporter_ReporterId". The conflict occurred in database "Taskist", table "dbo.Reporter", column 'Id'.

The INSERT statement conflicted with the FOREIGN KEY constraint "FK_Backlog_Sprint_SprintId". The conflict occurred in database "Taskist", table "dbo.Sprint", column 'Id'.
Solution- for non mandatory fields such as reporter, sprint etc, while creating new backlog , default value -1 was used, which threw above error. To fix this , added check for -1 value in AutoMapperProfile.cs file